### PR TITLE
Fix resource providers registration

### DIFF
--- a/docs/wiki/Deploy-SI-with-TF-Azure-CLI.md
+++ b/docs/wiki/Deploy-SI-with-TF-Azure-CLI.md
@@ -2,7 +2,7 @@
 
 The code is intended as an example for deployment of a single instance virtual machine with Oracle Database Enterprise Edition 19c. The code is intended to be used as a starting point for your own deployment. The module for this deployment is located in the `terraform/bootstrap/single_instance` directory.
 
- ![Single VM](media/single_vm.png)
+![Single VM](media/single_vm.png)
 
 ## Deployment steps
 
@@ -44,7 +44,10 @@ Perform the following steps to deploy the virtual machine:
 - Verify that you are in the `terraform/bootstrap/single_instance` directory.
 - Run the following commands to initialize Terraform state and deploy the virtual machine:
 
+* To avoid registering unnecessary providers, you have to export the environment variable `ARM_SKIP_PROVIDER_REGISTRATION` as `true`.
+
 ```bash
+export ARM_SKIP_PROVIDER_REGISTRATION=true
 terraform init
 terraform plan -var-file=fixtures.tfvars
 terraform apply -var-file=fixtures.tfvars
@@ -54,7 +57,7 @@ terraform apply -var-file=fixtures.tfvars
 
 Finally, you can connect to the virtual machine with ssh private key. While deploying resources, a public ip address is generated and attached to the virtual machine, so that you can connect to the virtual machine with this IP address. The username is `oracle`, which is hardcoded in `terraform/bootstrap/single_instance/module.tf`.
 
-As the deployment enables Just-in-Time VM access, you will need to request access to the VM before you can connect to it as described [here](https://learn.microsoft.com/en-us/azure/defender-for-cloud/just-in-time-access-usage#enable-jit-on-your-vms-from-microsoft-defender-for-cloud). 
+As the deployment enables Just-in-Time VM access, you will need to request access to the VM before you can connect to it as described [here](https://learn.microsoft.com/en-us/azure/defender-for-cloud/just-in-time-access-usage#enable-jit-on-your-vms-from-microsoft-defender-for-cloud).
 
 Once the VM is accessible, you can connect to it with the following command:
 
@@ -66,7 +69,7 @@ Next step is to proceed with Ansible configuration to get the Oracle database op
 
 ## Optional Settings
 
-There are a number of optional settings which the module enables. These are described below. Overall if you wish to modify one or more variables in the module, you can do so by modifying the `terraform/bootstrap/single_instance/variables_global.tf`  or the `terraform/bootstrap/single_instance/variables_local.tf` file.
+There are a number of optional settings which the module enables. These are described below. Overall if you wish to modify one or more variables in the module, you can do so by modifying the `terraform/bootstrap/single_instance/variables_global.tf` or the `terraform/bootstrap/single_instance/variables_local.tf` file.
 
 ### How to enable diagnostic settings
 
@@ -184,6 +187,3 @@ We set these as default values in ansible part.
     become_user: root
     register: redo_disks
 ```
-
-
-

--- a/docs/wiki/TERRAFORM.md
+++ b/docs/wiki/TERRAFORM.md
@@ -1,7 +1,5 @@
 # Provisioning of Azure VM via Terraform
 
-
-
 ## Prerequisites
 
 1. Azure Active Directory Tenant.
@@ -10,8 +8,6 @@
 ## Authenticate Terraform to Azure
 
 To use Terraform commands against your Azure subscription, you must first authenticate Terraform to that subscription. [This doc](https://learn.microsoft.com/en-us/azure/developer/terraform/authenticate-to-azure?tabs=bash) describes how to authenticate Terraform to your Azure subscription.
-
-
 
 ### How to deploy single VM for Oracle in the VNET
 
@@ -22,8 +18,6 @@ In this module, you will deploy single virtual machine in the virtual network.
 To deploy single Oracle instance on the VM, you can use **single_instance** module in this repo. The module is located on `terraform/bootstrap/single_instance` directory.
 
 Before using this module, you have to create your own ssh key to deploy and connect the virtual machine you will create. To do so, please follow the steps given below.
-
-
 
 1. Do the following on the compute source:
 
@@ -38,13 +32,12 @@ ls -lha ~/.ssh/
 
 2. Next, you go to `terraform/bootstrap/single_instance` directory and create `fixtures.tfvars` file as follows. The contents of the ssh public key that you created in the previous step are copied to the new file.
 
-
 ```bash
 cd ~/projects/lza-oracle/terraform/bootstrap/single_instance
 cat ~/.ssh/lza-oracle-single-instance.pub > fixtures.tfvars
 ```
 
-3. Edit the file and modify it so that the format matches the following. Make sure to include the double quotes. 
+3. Edit the file and modify it so that the format matches the following. Make sure to include the double quotes.
 
 ```bash
 nano  ~/projects/lza-oracle/terraform/bootstrap/single_instance/fixtures.tfvars
@@ -58,10 +51,13 @@ ssh_key = "ssh-rsa xxxxxxxxxxxxxx="
 
 <img src="../media/fixtures.jpg" />
 
-
 4. Next, execute below Terraform commands. When you deploy resources to Azure, you have to indicate `fixtures.tfvars` as a variable file, which contains the ssh public key.
 
+- To avoid registering unnecessary providers, you have to export the environment variable `ARM_SKIP_PROVIDER_REGISTRATION` as `true`.
+
 ```
+export ARM_SKIP_PROVIDER_REGISTRATION=true
+
 pwd
 
 ~/projects/lza-oracle/terraform/bootstrap/single_instance
@@ -75,11 +71,11 @@ terraform apply -var-file=fixtures.tfvars
 
 (When prompted for "Enter a value:" , type in "yes" and press Enter)
 
-
 (The "terraform plan" section should only take about 1-2 mins to run. If it takes any longer, interrupt the script and re-run).
 
 (If using Azure Cloud Shell, remember to refresh your browser by scrolling up or down, every 15 minutes or so since the shell times out after 20 minutes of inaction.)
 
+(If errors related to resource providers occur, you have to register `Microsoft.Network` and `Microsoft.Compute` providers).
 
 5. (OPTIONAL) Finally, you can connect to the virtual machine with ssh private key. While deploying resources, a public ip address is generated and attached to the virtual machine, so that you can connect to the virtual machine with this IP address. The username is `oracle`, which is fixed in `terraform/bootstrap/single_instance/module.tf`.
 
@@ -88,8 +84,6 @@ ssh -i ~/.ssh/lza-oracle-single-instance  oracle@<PUBLIC_IP_ADDRESS>
 ```
 
 6. Now you can go back to the main [README.md](../../README.md#step-by-step-instructions) file.
-
-
 
 ### How to enable diagnostic settings
 


### PR DESCRIPTION
When deploying resources for the first time after creating a new subscription, we encountered these errors.

![image](https://github.com/Azure/lza-oracle/assets/38392404/b2ac772a-4312-4bf4-bf40-658619a6344d)

![image](https://github.com/Azure/lza-oracle/assets/38392404/9fdf1ab1-52e3-4e35-acad-8c1514986c00)

To avoid this, we have to follow these steps.
１. export ARM_SKIP_PROVIDER_REGISTRATION=true
２. register Microsoft.Network and Microsoft.Compute providers